### PR TITLE
Update JWK URL

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -12,7 +12,7 @@ class Config(BaseSettings):
     REDIS_URL: RedisDsn
 
     JWKS_CACHE: JWKSet | None = None
-    JWKS_URL: str = "https://platform.pennlabs.org/identity/jwks/"
+    JWKS_URL: str = "https://platform.pennlabs.org/accounts/.well-known/jwks.json"
 
     SITE_DOMAIN: str = "analytics.pennlabs.org"
 


### PR DESCRIPTION
There is a new JWK URL (see @esinx presentation). 

This URL has been tested in a local environment and is functioning properly (where the old link was causing 401 Errors).