### PR TITLE
Analytics Serial Token Verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bullseye
 
 LABEL maintainer="Penn Labs"
 

--- a/src/auth.py
+++ b/src/auth.py
@@ -16,10 +16,8 @@ def get_jwks():
         for key in settings.JWKS_URL.keys():
             if key not in settings.JWKS_CACHE:
                 missing = True
-        
         if not missing:
             return settings.JWKS_CACHE
-
     # Make a request to get the JWKS
     for key in settings.JWKS_URL:
         try:
@@ -53,7 +51,6 @@ def verify_jwt(token: str = Depends(get_token_from_header)):
         try:
             decoded_token = jwt.JWT(key=key, jwt=token)
             return decoded_token.claims
-        except:
+        except Exception:
             pass
-    
-    raise HTTPException(status_code=401, detail="Failed to verify JWT token against public keys array.")
+    raise HTTPException(status_code=401, detail="Failed to verify JWT token")

--- a/src/auth.py
+++ b/src/auth.py
@@ -13,7 +13,6 @@ def get_jwks():
             if key not in settings.JWKS_CACHE:
                 missing = True
         if not missing:
-            print("Can used cached keys")
             return settings.JWKS_CACHE
     # Make a request to get the JWKS
     for key in settings.JWKS_URL:

--- a/src/auth.py
+++ b/src/auth.py
@@ -5,10 +5,6 @@ from jwcrypto import jwk, jwt
 from src.config import settings
 
 
-# The URL to the JWKS endpoint
-JWKS_URL = settings.JWKS_URL
-
-
 def get_jwks():
     if settings.JWKS_CACHE:
         # Check to make sure we have a cached JWK for each key, otherwise refetch all.
@@ -17,15 +13,16 @@ def get_jwks():
             if key not in settings.JWKS_CACHE:
                 missing = True
         if not missing:
+            print("Can used cached keys")
             return settings.JWKS_CACHE
     # Make a request to get the JWKS
     for key in settings.JWKS_URL:
         try:
-            response = requests.get(JWKS_URL)
+            response = requests.get(settings.JWKS_URL[key])
             jwks = jwk.JWKSet.from_json(response.text)
             settings.JWKS_CACHE[key] = jwks
         except Exception as e:
-            del settings.JWKS_CACHE[key]
+            print(str(e))
             raise HTTPException(status_code=500, detail=str(e))
     return settings.JWKS_CACHE
 
@@ -49,7 +46,7 @@ def verify_jwt(token: str = Depends(get_token_from_header)):
     public_keys = get_jwks()
     for key in public_keys:
         try:
-            decoded_token = jwt.JWT(key=key, jwt=token)
+            decoded_token = jwt.JWT(key=public_keys[key], jwt=token)
             return decoded_token.claims
         except Exception:
             pass

--- a/src/auth.py
+++ b/src/auth.py
@@ -9,19 +9,26 @@ from src.config import settings
 JWKS_URL = settings.JWKS_URL
 
 
-def get_jwk():
+def get_jwks():
     if settings.JWKS_CACHE:
-        key = settings.JWKS_CACHE
-        return key
+        # Check to make sure we have a cached JWK for each key, otherwise refetch all.
+        missing = False
+        for key in settings.JWKS_URL.keys():
+            if key not in settings.JWKS_CACHE:
+                missing = True
+        
+        if not missing:
+            return settings.JWKS_CACHE
 
     # Make a request to get the JWKS
-    try:
-        response = requests.get(JWKS_URL)
-        jwks = jwk.JWKSet.from_json(response.text)
-        settings.JWKS_CACHE = jwks
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
+    for key in settings.JWKS_URL:
+        try:
+            response = requests.get(JWKS_URL)
+            jwks = jwk.JWKSet.from_json(response.text)
+            settings.JWKS_CACHE[key] = jwks
+        except Exception as e:
+            del settings.JWKS_CACHE[key]
+            raise HTTPException(status_code=500, detail=str(e))
     return settings.JWKS_CACHE
 
 
@@ -41,11 +48,12 @@ def get_token_from_header(request: Request):
 
 
 def verify_jwt(token: str = Depends(get_token_from_header)):
-    try:
-        # Load the public key
-        public_key = get_jwk()
-        # Decode and verify the JWT
-        decoded_token = jwt.JWT(key=public_key, jwt=token)
-        return decoded_token.claims
-    except Exception as e:
-        raise HTTPException(status_code=401, detail=str(e))
+    public_keys = get_jwks()
+    for key in public_keys:
+        try:
+            decoded_token = jwt.JWT(key=key, jwt=token)
+            return decoded_token.claims
+        except:
+            pass
+    
+    raise HTTPException(status_code=401, detail="Failed to verify JWT token against public keys array.")

--- a/src/config.py
+++ b/src/config.py
@@ -11,7 +11,7 @@ class Config(BaseSettings):
     DATABASE_URL: PostgresDsn
     REDIS_URL: RedisDsn
 
-    JWKS_CACHE: list[JWKSet] | None = None
+    JWKS_CACHE: dict[str, JWKSet] = {}
     JWKS_URL: dict[str, str] = {
         "b2b": "https://platform.pennlabs.org/identity/jwks/",
         "user": "https://platform.pennlabs.org/accounts/.well-known/jwks.json",

--- a/src/config.py
+++ b/src/config.py
@@ -11,8 +11,11 @@ class Config(BaseSettings):
     DATABASE_URL: PostgresDsn
     REDIS_URL: RedisDsn
 
-    JWKS_CACHE: JWKSet | None = None
-    JWKS_URL: str = "https://platform.pennlabs.org/identity/jwks/"
+    JWKS_CACHE: list[JWKSet] | None = None
+    JWKS_URL: dict[str, str] = {
+        "b2b":"https://platform.pennlabs.org/identity/jwks/",
+        "user":"https://platform.pennlabs.org/accounts/.well-known/jwks.json"
+    }
 
     SITE_DOMAIN: str = "analytics.pennlabs.org"
 

--- a/src/config.py
+++ b/src/config.py
@@ -13,10 +13,9 @@ class Config(BaseSettings):
 
     JWKS_CACHE: list[JWKSet] | None = None
     JWKS_URL: dict[str, str] = {
-        "b2b":"https://platform.pennlabs.org/identity/jwks/",
-        "user":"https://platform.pennlabs.org/accounts/.well-known/jwks.json"
+        "b2b": "https://platform.pennlabs.org/identity/jwks/",
+        "user": "https://platform.pennlabs.org/accounts/.well-known/jwks.json",
     }
-
     SITE_DOMAIN: str = "analytics.pennlabs.org"
 
     ENVIRONMENT: Environment = Environment.PRODUCTION

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -5,7 +5,8 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
 import requests
-from test_token import get_tokens
+
+from tests.test_token import get_tokens
 
 
 # Runtime should be less that 3 seconds for most laptops
@@ -19,7 +20,7 @@ THREADS = 16
 def make_request():
     access_token, _ = get_tokens()
 
-    url = "http://localhost:8000/analytics"
+    url = "http://localhost:80/analytics/"
     payload = json.dumps(
         {
             "product": random.randint(1, 10),

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -17,10 +17,8 @@ NUMBER_OF_REQUESTS = 1000
 THREADS = 16
 
 
-def make_request():
-    access_token, _ = get_tokens()
-
-    url = "http://localhost:80/analytics/"
+def make_request(token: str):
+    url = "http://localhost:8000/analytics/"
     payload = json.dumps(
         {
             "product": random.randint(1, 10),
@@ -42,7 +40,7 @@ def make_request():
     )
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {access_token}",
+        "Authorization": f"Bearer {token}",
     }
 
     try:
@@ -56,8 +54,10 @@ def make_request():
 
 def run_threads():
     with ThreadPoolExecutor(max_workers=THREADS) as executor:
+        # Fetch token once to improve performance
+        access_token, _ = get_tokens()
         for _ in range(NUMBER_OF_REQUESTS):
-            executor.submit(make_request)
+            executor.submit(make_request, access_token)
 
 
 def test_load():


### PR DESCRIPTION
- Use two schemes for validating JWK, useful for both frontend and b2b JWTs.
- Update image to python:3.11-bullseye, since the previous version was no longer supported (unavailable from the debian CDN)
- make it so the tests actually pass