### PR TITLE
Upgrade to 3.11-bullseye for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.11-bullseye
 
 LABEL maintainer="Penn Labs"
 


### PR DESCRIPTION
Buster is busted.

(has been deprecated, no longer available on apt-get/docker repo)